### PR TITLE
CI on JDK 25; update Gradle to 9.4.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        jdk: [11, 17, 21]
+        jdk: [17, 21, 25]
 
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.gradle/
+build/
+.idea/
+.tmp/
+*.hprof
+heapdump_jmemb_*.hprof

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$JUNIT_VERSION"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$JUNIT_VERSION"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$JUNIT_VERSION"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.11.3" // required explicitly since Gradle 9
     testRuntimeOnly "ch.qos.logback:logback-classic:$LOGBACK_VERSION"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Bump the Gradle wrapper 8.8 → 9.4.1 (required for JDK 25).
- CI matrix `[11,17,21]` → `[17,21,25]` — Gradle 9 requires JDK 17+ to run; the library still targets Java 11 (`sourceCompatibility = 11`).
- Add `junit-platform-launcher` explicitly (Gradle 9 no longer adds it automatically).

Verified: `build` + full test suite green on JDK 25, including the HPROF path-printing tests (parser handles JDK 25 dumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)